### PR TITLE
return null if class is abstract

### DIFF
--- a/Configuration/Metadata/Driver/AnnotationDriver.php
+++ b/Configuration/Metadata/Driver/AnnotationDriver.php
@@ -44,7 +44,11 @@ class AnnotationDriver implements DriverInterface
     public function loadMetadataForClass(\ReflectionClass $class)
     {
         $annotations = $this->reader->getClassAnnotations($class);
-
+        
+        if ($class->isAbstract()) {
+            return null;
+        }
+        
         if (0 === count($annotations)) {
             return null;
         }


### PR DESCRIPTION
prevents abstract base classes from having their annotations read when serializing a class that inherits from the base class
